### PR TITLE
Add interactive stock chart options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ai-trade
 
-This project provides a simple example of fetching stock data from Yahoo Finance and displaying it on the web.
+This project provides a simple example of fetching stock data from Yahoo Finance and displaying it on the web. The `/stock/<ticker>` page now renders an interactive Plotly chart with selectable time periods and chart types (line or candlestick) similar to options found in trading apps.
 
 ## Requirements
 

--- a/app.py
+++ b/app.py
@@ -1,5 +1,7 @@
-from flask import Flask, render_template_string
+from flask import Flask, render_template_string, request
 import yfinance as yf
+import plotly.graph_objects as go
+import plotly.io as pio
 
 app = Flask(__name__)
 
@@ -10,6 +12,20 @@ template = """
 {% if error %}
 <p style='color: red;'>{{ error }}</p>
 {% else %}
+<form method="get">
+    Period:
+    <select name="period" onchange="this.form.submit()">
+        {% for p in ['5d', '1mo', '3mo', '6mo', '1y'] %}
+        <option value="{{ p }}" {% if p == period %}selected{% endif %}>{{ p }}</option>
+        {% endfor %}
+    </select>
+    Chart Type:
+    <select name="chart_type" onchange="this.form.submit()">
+        <option value="line" {% if chart_type == 'line' %}selected{% endif %}>Line</option>
+        <option value="candlestick" {% if chart_type == 'candlestick' %}selected{% endif %}>Candlestick</option>
+    </select>
+</form>
+{{ graph|safe }}
 <table border="1">
 <tr><th>Date</th><th>Open</th><th>High</th><th>Low</th><th>Close</th><th>Volume</th></tr>
 {% for date, row in data.iterrows() %}
@@ -20,7 +36,6 @@ template = """
 <td>{{ '{:.2f}'.format(row['Low']) }}</td>
 <td>{{ '{:.2f}'.format(row['Close']) }}</td>
 <td>{{ row['Volume']|int }}</td>
-
 </tr>
 {% endfor %}
 </table>
@@ -29,14 +44,34 @@ template = """
 
 @app.route('/stock/<ticker>')
 def stock(ticker):
+    period = request.args.get('period', '5d')
+    chart_type = request.args.get('chart_type', 'line')
     try:
         stock = yf.Ticker(ticker)
-        data = stock.history(period="5d")
+        data = stock.history(period=period)
         if data.empty:
             raise ValueError("No data found for ticker")
-        return render_template_string(template, ticker=ticker, data=data, error=None)
+
+        if chart_type == 'candlestick':
+            fig = go.Figure(data=[go.Candlestick(x=data.index,
+                                                 open=data['Open'],
+                                                 high=data['High'],
+                                                 low=data['Low'],
+                                                 close=data['Close'])])
+        else:
+            fig = go.Figure()
+            fig.add_trace(go.Scatter(x=data.index, y=data['Close'], mode='lines', name='Close'))
+
+        fig.update_layout(title=f"{ticker} Price", xaxis_title="Date", yaxis_title="Price")
+        graph_html = pio.to_html(fig, full_html=False)
+
+        return render_template_string(template, ticker=ticker, data=data,
+                                      period=period, chart_type=chart_type,
+                                      graph=graph_html, error=None)
     except Exception as e:
-        return render_template_string(template, ticker=ticker, data=None, error=str(e))
+        return render_template_string(template, ticker=ticker, data=None,
+                                      period=period, chart_type=chart_type,
+                                      graph='', error=str(e))
 
 if __name__ == '__main__':
     app.run(debug=True, host='0.0.0.0')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask
 yfinance
+plotly


### PR DESCRIPTION
## Summary
- show a Plotly stock chart and table of data
- support selecting time period and chart type
- document the new interactive chart feature
- include plotly as dependency

## Testing
- `python -m py_compile app.py`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68413dc79dd8832b98e2eaaec5b8e23b