### PR TITLE
Add basic authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,7 @@ python app.py
 
 The home page at `http://localhost:5000/` lets you save tickers and search existing ones.
 Click any saved ticker to view the interactive chart at `/stock/<ticker>`.
+
+## Login
+
+The application now supports user accounts. Visit `/register` to create an account and `/login` to sign in. Once logged in, you can add and view saved tickers. Use `/logout` to end the session.

--- a/app.py
+++ b/app.py
@@ -1,145 +1,16 @@
-from flask import Flask, render_template_string, request, url_for, redirect
-import sqlite3
-import yfinance as yf
-import plotly.graph_objects as go
-import plotly.io as pio
+from flask import Flask
+
+import db
+from auth import bp as auth_bp
+from stocks import bp as stocks_bp
 
 app = Flask(__name__)
+app.secret_key = 'change-me'
 
-DB_PATH = 'stocks.db'
+app.register_blueprint(auth_bp)
+app.register_blueprint(stocks_bp)
 
-
-def get_db():
-    conn = sqlite3.connect(DB_PATH)
-    conn.row_factory = sqlite3.Row
-    return conn
-
-
-def init_db():
-    conn = get_db()
-    conn.execute('CREATE TABLE IF NOT EXISTS tickers (id INTEGER PRIMARY KEY AUTOINCREMENT, ticker TEXT UNIQUE)')
-    conn.commit()
-    conn.close()
-
-
-init_db()
-
-index_template = """
-<!doctype html>
-<title>Saved Stocks</title>
-<h1>Saved Tickers</h1>
-<form method="post">
-    <input name="ticker" placeholder="Add ticker" />
-    <button type="submit">Add</button>
-</form>
-{% if message %}
-<p style="color:red;">{{ message }}</p>
-{% endif %}
-<form method="get">
-    <input name="q" placeholder="Search" value="{{ search }}" />
-    <button type="submit">Search</button>
-</form>
-<ul>
-{% for t in tickers %}
-    <li><a href="{{ url_for('stock', ticker=t) }}">{{ t }}</a></li>
-{% else %}
-    <li>No tickers found.</li>
-{% endfor %}
-</ul>
-"""
-
-
-@app.route('/', methods=['GET', 'POST'])
-def index():
-    conn = get_db()
-    cursor = conn.cursor()
-    message = None
-    if request.method == 'POST':
-        ticker = request.form.get('ticker', '').upper().strip()
-        if ticker:
-            try:
-                cursor.execute('INSERT INTO tickers (ticker) VALUES (?)', (ticker,))
-                conn.commit()
-                conn.close()
-                return redirect(url_for('index'))
-            except sqlite3.IntegrityError:
-                message = 'Ticker already saved.'
-    search = request.args.get('q', '').upper()
-    if search:
-        cursor.execute('SELECT ticker FROM tickers WHERE ticker LIKE ?', (f"%{search}%",))
-    else:
-        cursor.execute('SELECT ticker FROM tickers')
-    tickers = [row['ticker'] for row in cursor.fetchall()]
-    conn.close()
-    return render_template_string(index_template, tickers=tickers, search=search, message=message)
-
-template = """
-<!doctype html>
-<title>Stock Data</title>
-<h1>Stock Data for {{ ticker }}</h1>
-{% if error %}
-<p style='color: red;'>{{ error }}</p>
-{% else %}
-<form method="get">
-    Period:
-    <select name="period" onchange="this.form.submit()">
-        {% for p in ['5d', '1mo', '3mo', '6mo', '1y'] %}
-        <option value="{{ p }}" {% if p == period %}selected{% endif %}>{{ p }}</option>
-        {% endfor %}
-    </select>
-    Chart Type:
-    <select name="chart_type" onchange="this.form.submit()">
-        <option value="line" {% if chart_type == 'line' %}selected{% endif %}>Line</option>
-        <option value="candlestick" {% if chart_type == 'candlestick' %}selected{% endif %}>Candlestick</option>
-    </select>
-</form>
-{{ graph|safe }}
-<table border="1">
-<tr><th>Date</th><th>Open</th><th>High</th><th>Low</th><th>Close</th><th>Volume</th></tr>
-{% for date, row in data.iterrows() %}
-<tr>
-<td>{{ date.date() }}</td>
-<td>{{ '{:.2f}'.format(row['Open']) }}</td>
-<td>{{ '{:.2f}'.format(row['High']) }}</td>
-<td>{{ '{:.2f}'.format(row['Low']) }}</td>
-<td>{{ '{:.2f}'.format(row['Close']) }}</td>
-<td>{{ row['Volume']|int }}</td>
-</tr>
-{% endfor %}
-</table>
-{% endif %}
-"""
-
-@app.route('/stock/<ticker>')
-def stock(ticker):
-    period = request.args.get('period', '5d')
-    chart_type = request.args.get('chart_type', 'line')
-    try:
-        stock = yf.Ticker(ticker)
-        data = stock.history(period=period)
-        if data.empty:
-            raise ValueError("No data found for ticker")
-
-        if chart_type == 'candlestick':
-            fig = go.Figure(data=[go.Candlestick(x=data.index,
-                                                 open=data['Open'],
-                                                 high=data['High'],
-                                                 low=data['Low'],
-                                                 close=data['Close'])])
-        else:
-            fig = go.Figure()
-            fig.add_trace(go.Scatter(x=data.index, y=data['Close'], mode='lines', name='Close'))
-
-        fig.update_layout(title=f"{ticker} Price", xaxis_title="Date", yaxis_title="Price")
-        graph_html = pio.to_html(fig, full_html=False)
-
-        return render_template_string(template, ticker=ticker, data=data,
-                                      period=period, chart_type=chart_type,
-                                      graph=graph_html, error=None)
-    except Exception as e:
-        return render_template_string(template, ticker=ticker, data=None,
-                                      period=period, chart_type=chart_type,
-                                      graph='', error=str(e))
+db.init_db()
 
 if __name__ == '__main__':
     app.run(debug=True, host='0.0.0.0')

--- a/auth.py
+++ b/auth.py
@@ -1,0 +1,110 @@
+from functools import wraps
+from flask import (
+    Blueprint,
+    request,
+    session,
+    g,
+    redirect,
+    url_for,
+    render_template_string,
+)
+from werkzeug.security import generate_password_hash, check_password_hash
+
+from db import get_db
+
+bp = Blueprint('auth', __name__)
+
+login_template = """
+<!doctype html>
+<title>Login</title>
+<h1>Login</h1>
+<form method="post">
+    <input name="username" placeholder="Username" />
+    <input name="password" type="password" placeholder="Password" />
+    <button type="submit">Login</button>
+</form>
+{% if message %}<p style='color:red;'>{{ message }}</p>{% endif %}
+<p><a href="{{ url_for('auth.register') }}">Register</a></p>
+"""
+
+register_template = """
+<!doctype html>
+<title>Register</title>
+<h1>Register</h1>
+<form method="post">
+    <input name="username" placeholder="Username" />
+    <input name="password" type="password" placeholder="Password" />
+    <button type="submit">Register</button>
+</form>
+{% if message %}<p style='color:red;'>{{ message }}</p>{% endif %}
+<p><a href="{{ url_for('auth.login') }}">Login</a></p>
+"""
+
+
+@bp.before_app_request
+def load_logged_in_user():
+    user_id = session.get('user_id')
+    if user_id is None:
+        g.user = None
+    else:
+        conn = get_db()
+        g.user = conn.execute('SELECT * FROM users WHERE id = ?', (user_id,)).fetchone()
+        conn.close()
+
+
+def login_required(view):
+    @wraps(view)
+    def wrapped(*args, **kwargs):
+        if g.get('user') is None:
+            return redirect(url_for('auth.login'))
+        return view(*args, **kwargs)
+
+    return wrapped
+
+
+@bp.route('/login', methods=['GET', 'POST'])
+def login():
+    message = None
+    if request.method == 'POST':
+        username = request.form['username']
+        password = request.form['password']
+        conn = get_db()
+        user = conn.execute('SELECT * FROM users WHERE username = ?', (username,)).fetchone()
+        conn.close()
+        if user and check_password_hash(user['password_hash'], password):
+            session.clear()
+            session['user_id'] = user['id']
+            return redirect(url_for('stocks.index'))
+        else:
+            message = 'Invalid credentials.'
+    return render_template_string(login_template, message=message)
+
+
+@bp.route('/register', methods=['GET', 'POST'])
+def register():
+    message = None
+    if request.method == 'POST':
+        username = request.form['username']
+        password = request.form['password']
+        if not username or not password:
+            message = 'Username and password required.'
+        else:
+            conn = get_db()
+            try:
+                conn.execute(
+                    'INSERT INTO users (username, password_hash) VALUES (?, ?)',
+                    (username, generate_password_hash(password)),
+                )
+                conn.commit()
+                conn.close()
+                return redirect(url_for('auth.login'))
+            except Exception:
+                conn.close()
+                message = 'Username already exists.'
+    return render_template_string(register_template, message=message)
+
+
+@bp.route('/logout')
+def logout():
+    session.clear()
+    return redirect(url_for('auth.login'))

--- a/db.py
+++ b/db.py
@@ -1,0 +1,27 @@
+import sqlite3
+
+DB_PATH = 'stocks.db'
+
+
+def get_db():
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def init_db():
+    conn = get_db()
+    conn.execute(
+        'CREATE TABLE IF NOT EXISTS tickers (id INTEGER PRIMARY KEY AUTOINCREMENT, ticker TEXT UNIQUE)'
+    )
+    conn.execute(
+        '''
+        CREATE TABLE IF NOT EXISTS users (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            username TEXT UNIQUE,
+            password_hash TEXT
+        )
+        '''
+    )
+    conn.commit()
+    conn.close()

--- a/stocks.py
+++ b/stocks.py
@@ -1,0 +1,146 @@
+from flask import (
+    Blueprint,
+    render_template_string,
+    request,
+    redirect,
+    url_for,
+)
+import yfinance as yf
+import plotly.graph_objects as go
+import plotly.io as pio
+
+from db import get_db
+from auth import login_required
+
+bp = Blueprint('stocks', __name__)
+
+index_template = """
+<!doctype html>
+<title>Saved Stocks</title>
+{% if g.user %}
+<p>Logged in as {{ g.user['username'] }} | <a href="{{ url_for('auth.logout') }}">Logout</a></p>
+{% else %}
+<p><a href="{{ url_for('auth.login') }}">Login</a> | <a href="{{ url_for('auth.register') }}">Register</a></p>
+{% endif %}
+<h1>Saved Tickers</h1>
+<form method="post">
+    <input name="ticker" placeholder="Add ticker" />
+    <button type="submit">Add</button>
+</form>
+{% if message %}
+<p style="color:red;">{{ message }}</p>
+{% endif %}
+<form method="get">
+    <input name="q" placeholder="Search" value="{{ search }}" />
+    <button type="submit">Search</button>
+</form>
+<ul>
+{% for t in tickers %}
+    <li><a href="{{ url_for('stocks.stock', ticker=t) }}">{{ t }}</a></li>
+{% else %}
+    <li>No tickers found.</li>
+{% endfor %}
+</ul>
+"""
+
+template = """
+<!doctype html>
+<title>Stock Data</title>
+{% if g.user %}
+<p>Logged in as {{ g.user['username'] }} | <a href="{{ url_for('auth.logout') }}">Logout</a></p>
+{% else %}
+<p><a href="{{ url_for('auth.login') }}">Login</a> | <a href="{{ url_for('auth.register') }}">Register</a></p>
+{% endif %}
+<h1>Stock Data for {{ ticker }}</h1>
+{% if error %}
+<p style='color: red;'>{{ error }}</p>
+{% else %}
+<form method="get">
+    Period:
+    <select name="period" onchange="this.form.submit()">
+        {% for p in ['5d', '1mo', '3mo', '6mo', '1y'] %}
+        <option value="{{ p }}" {% if p == period %}selected{% endif %}>{{ p }}</option>
+        {% endfor %}
+    </select>
+    Chart Type:
+    <select name="chart_type" onchange="this.form.submit()">
+        <option value="line" {% if chart_type == 'line' %}selected{% endif %}>Line</option>
+        <option value="candlestick" {% if chart_type == 'candlestick' %}selected{% endif %}>Candlestick</option>
+    </select>
+</form>
+{{ graph|safe }}
+<table border="1">
+<tr><th>Date</th><th>Open</th><th>High</th><th>Low</th><th>Close</th><th>Volume</th></tr>
+{% for date, row in data.iterrows() %}
+<tr>
+<td>{{ date.date() }}</td>
+<td>{{ '{:.2f}'.format(row['Open']) }}</td>
+<td>{{ '{:.2f}'.format(row['High']) }}</td>
+<td>{{ '{:.2f}'.format(row['Low']) }}</td>
+<td>{{ '{:.2f}'.format(row['Close']) }}</td>
+<td>{{ row['Volume']|int }}</td>
+</tr>
+{% endfor %}
+</table>
+{% endif %}
+"""
+
+
+@bp.route('/', methods=['GET', 'POST'])
+@login_required
+def index():
+    conn = get_db()
+    cursor = conn.cursor()
+    message = None
+    if request.method == 'POST':
+        ticker = request.form.get('ticker', '').upper().strip()
+        if ticker:
+            try:
+                cursor.execute('INSERT INTO tickers (ticker) VALUES (?)', (ticker,))
+                conn.commit()
+                conn.close()
+                return redirect(url_for('stocks.index'))
+            except Exception:
+                message = 'Ticker already saved.'
+    search = request.args.get('q', '').upper()
+    if search:
+        cursor.execute('SELECT ticker FROM tickers WHERE ticker LIKE ?', (f"%{search}%",))
+    else:
+        cursor.execute('SELECT ticker FROM tickers')
+    tickers = [row['ticker'] for row in cursor.fetchall()]
+    conn.close()
+    return render_template_string(index_template, tickers=tickers, search=search, message=message)
+
+
+@bp.route('/stock/<ticker>')
+@login_required
+def stock(ticker):
+    period = request.args.get('period', '5d')
+    chart_type = request.args.get('chart_type', 'line')
+    try:
+        stock = yf.Ticker(ticker)
+        data = stock.history(period=period)
+        if data.empty:
+            raise ValueError("No data found for ticker")
+
+        if chart_type == 'candlestick':
+            fig = go.Figure(data=[go.Candlestick(x=data.index,
+                                                 open=data['Open'],
+                                                 high=data['High'],
+                                                 low=data['Low'],
+                                                 close=data['Close'])])
+        else:
+            fig = go.Figure()
+            fig.add_trace(go.Scatter(x=data.index, y=data['Close'], mode='lines', name='Close'))
+
+        fig.update_layout(title=f"{ticker} Price", xaxis_title="Date", yaxis_title="Price")
+        graph_html = pio.to_html(fig, full_html=False)
+
+        return render_template_string(template, ticker=ticker, data=data,
+                                      period=period, chart_type=chart_type,
+                                      graph=graph_html, error=None)
+    except Exception as e:
+        return render_template_string(template, ticker=ticker, data=None,
+                                      period=period, chart_type=chart_type,
+                                      graph='', error=str(e))
+


### PR DESCRIPTION
## Summary
- initialize `users` table
- add login/logout/register routes and session management
- decorate routes with `login_required`
- show auth links in stock pages
- document login in README
- break application into `db`, `auth`, and `stocks` modules

## Testing
- `python -m py_compile app.py auth.py stocks.py db.py`


------
https://chatgpt.com/codex/tasks/task_e_684144c79ec4832bb810fdee3c4a0ae8