### PR TITLE
Add stock news display

### DIFF
--- a/stocks.py
+++ b/stocks.py
@@ -148,6 +148,14 @@ template = """
       <li>Day {{ loop.index }}: {{ '{:.2f}'.format(price) }}</li>
       {% endfor %}
     </ul>
+    <h2 class=\"mt-4\">Latest News</h2>
+    <ul>
+      {% for n in news %}
+      <li><a href="{{ n['link'] }}" target="_blank">{{ n['title'] }}</a>{% if n.get('publisher') %} ({{ n['publisher'] }}){% endif %}</li>
+      {% else %}
+      <li>No recent news found.</li>
+      {% endfor %}
+    </ul>
   {% endif %}
 </div>
 </body>
@@ -205,14 +213,42 @@ def stock(ticker):
         fig.update_layout(title=f"{ticker} Price", xaxis_title="Date", yaxis_title="Price", template="plotly_white")
         graph_html = pio.to_html(fig, full_html=False)
         preds = predict_prices(data)
+        news = []
+        try:
+            fetched = []
+            if hasattr(stock, 'get_news'):
+                fetched = stock.get_news()
+            elif hasattr(stock, 'news'):
+                fetched = stock.news
 
-        return render_template_string(template, ticker=ticker, data=data,
-                                      period=period, chart_type=chart_type,
-                                      graph=graph_html, predictions=preds,
-                                      error=None)
+            if hasattr(fetched, 'to_dict'):
+                fetched = fetched.to_dict('records')
+
+            news = list(fetched)[:5]
+        except Exception:
+            news = []
+
+        return render_template_string(
+            template,
+            ticker=ticker,
+            data=data,
+            period=period,
+            chart_type=chart_type,
+            graph=graph_html,
+            predictions=preds,
+            news=news,
+            error=None,
+        )
     except Exception as e:
-        return render_template_string(template, ticker=ticker, data=None,
-                                      period=period, chart_type=chart_type,
-                                      graph='', predictions=[],
-                                      error=str(e))
+        return render_template_string(
+            template,
+            ticker=ticker,
+            data=None,
+            period=period,
+            chart_type=chart_type,
+            graph='',
+            predictions=[],
+            news=[],
+            error=str(e),
+        )
 


### PR DESCRIPTION
## Summary
- show recent news for a ticker
- gracefully handle no news available
- fix handling when yfinance returns a DataFrame

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68417ccd4440832b96de78ba69dd243e