### PR TITLE
Fix news fetch using RSS fallback

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask
 yfinance
 plotly
+feedparser


### PR DESCRIPTION
## Summary
- use `feedparser` to fetch stock news from Yahoo as fallback
- simplify news gathering logic in stock view
- add `feedparser` requirement

## Testing
- `python -m py_compile stocks.py app.py auth.py db.py`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684183d26ed8832ba506ab3f7081259c