### PR TITLE
Add GPT-based analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Install dependencies with:
 pip install -r requirements.txt
 ```
 
+Set `OPENAI_API_KEY` in your environment to enable GPT-powered sentiment
+analysis and price predictions.
+
 ## Usage
 
 Run the Flask application:
@@ -20,6 +23,11 @@ python app.py
 
 The home page at `http://localhost:5000/` lets you save tickers and search existing ones.
 Click any saved ticker to view the interactive chart at `/stock/<ticker>`.
+
+Each stock page includes average sentiment from the latest news headlines.
+If an `OPENAI_API_KEY` environment variable is set, GPT is used to analyze
+the headlines and provide price forecasts. Otherwise VADER performs a simple
+sentiment check to adjust the naive predictions.
 
 ## Login
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ Flask
 yfinance
 plotly
 feedparser
+vaderSentiment
+openai


### PR DESCRIPTION
## Summary
- allow GPT-based sentiment and price forecasts using OPENAI_API_KEY
- document GPT support in README
- add openai to requirements

## Testing
- `python -m py_compile app.py auth.py db.py stocks.py`

------
https://chatgpt.com/codex/tasks/task_e_68418848b52c832b98f449df8999576b