### PR TITLE
Add CLI simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,15 @@ sentiment check to adjust the naive predictions.
 ## Login
 
 The application now supports user accounts. Visit `/register` to create an account and `/login` to sign in. Registration requires an email address. A verification link will be displayed after signing up; open the link to activate your account before logging in. Once logged in, you can add and view saved tickers. Use `/logout` to end the session.
+
+## Simulation
+
+A command line script `simulation.py` runs a simple buy-and-hold simulation using the predicted closing prices.
+Provide a ticker and optionally an initial balance and number of days:
+
+```bash
+python simulation.py AAPL 10000 5
+```
+
+This fetches recent data for `AAPL`, predicts the next 5 closing prices and shows the projected portfolio value if you purchased shares with the given balance.
+

--- a/simulation.py
+++ b/simulation.py
@@ -1,0 +1,35 @@
+import sys
+import yfinance as yf
+
+from stocks import fetch_news, analyze_sentiment, predict_prices
+
+
+def simulate(ticker, balance=10000, days=5):
+    """Run a simple buy-and-hold simulation using predicted prices."""
+    stock = yf.Ticker(ticker)
+    data = stock.history(period='1mo')
+    if data.empty or 'Close' not in data:
+        print('No data available for', ticker)
+        return
+    last_close = float(data['Close'].iloc[-1])
+    news = fetch_news(ticker, stock)
+    sentiment = analyze_sentiment(news)
+    predictions = predict_prices(data, days=days, sentiment=sentiment)
+    if not predictions:
+        print('Unable to generate predictions')
+        return
+    shares = balance / last_close
+    print(f'Starting with ${balance:.2f} and buying {shares:.2f} shares at ${last_close:.2f}')
+    for i, price in enumerate(predictions, start=1):
+        value = shares * price
+        print(f'Day {i}: predicted close ${price:.2f}, portfolio value ${value:.2f}')
+
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print('Usage: python simulation.py TICKER [balance] [days]')
+        sys.exit(1)
+    ticker = sys.argv[1].upper()
+    balance = float(sys.argv[2]) if len(sys.argv) > 2 else 10000
+    days = int(sys.argv[3]) if len(sys.argv) > 3 else 5
+    simulate(ticker, balance, days)


### PR DESCRIPTION
## Summary
- add a simple `simulation.py` script to run a buy-and-hold simulation
- document the new script in the README

## Testing
- `python -m py_compile app.py auth.py db.py stocks.py simulation.py`
- `pip install -q -r requirements.txt` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68418e64ed04832b95b40c105e3c2c7a