### PR TITLE
Improve Korean mobile layout

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -19,9 +19,10 @@ bp = Blueprint('auth', __name__)
 
 login_template = """
 <!doctype html>
-<html lang=\"en\">
+<html lang=\"ko\">
 <head>
 <meta charset=\"utf-8\">
+<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
 <link href=\"https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css\" rel=\"stylesheet\">
 <title>Login</title>
 </head>
@@ -44,9 +45,10 @@ login_template = """
 
 register_template = """
 <!doctype html>
-<html lang=\"en\">
+<html lang=\"ko\">
 <head>
 <meta charset=\"utf-8\">
+<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
 <link href=\"https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css\" rel=\"stylesheet\">
 <title>Register</title>
 </head>
@@ -72,9 +74,10 @@ register_template = """
 
 verify_template = """
 <!doctype html>
-<html lang=\"en\">
+<html lang=\"ko\">
 <head>
 <meta charset=\"utf-8\">
+<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
 <link href=\"https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css\" rel=\"stylesheet\">
 <title>Email Verification</title>
 </head>

--- a/stocks.py
+++ b/stocks.py
@@ -200,9 +200,10 @@ def run_simulation(data, predictions, balance):
 
 index_template = """
 <!doctype html>
-<html lang=\"en\">
+<html lang=\"ko\">
 <head>
   <meta charset=\"utf-8\">
+  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
   <link href=\"https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css\" rel=\"stylesheet\">
   <title>Saved Stocks</title>
 </head>
@@ -250,9 +251,10 @@ index_template = """
 
 template = """
 <!doctype html>
-<html lang=\"en\">
+<html lang=\"ko\">
 <head>
   <meta charset=\"utf-8\">
+  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
   <link href=\"https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css\" rel=\"stylesheet\">
   <title>{{ ticker }} Data</title>
 </head>


### PR DESCRIPTION
## Summary
- set `lang="ko"` and `meta viewport` on login and register pages
- set `lang="ko"` and `meta viewport` on stock templates

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684198436e94832b8c0f8550d3865f5c