### PR TITLE
Add adaptive trading simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ The application now supports user accounts. Visit `/register` to create an accou
 
 ## Simulation
 
-A command line script `simulation.py` runs a simple buy-and-hold simulation using the predicted closing prices.
+A command line script `simulation.py` runs an adaptive trading simulation using the predicted closing prices.
 Provide a ticker and optionally an initial balance and number of days:
 
 ```bash
 python simulation.py AAPL 10000 5
 ```
 
-This fetches recent data for `AAPL`, predicts the next 5 closing prices and shows the projected portfolio value if you purchased shares with the given balance.
+This fetches recent data for `AAPL`, predicts the next 5 closing prices and shows the portfolio value while automatically buying or selling based on the forecast. If prices are expected to fall for the entire period, the simulation reports that no buy signal occurred.
 
 On each stock page you can also run this simulation in the browser. Enter a seed
 amount and number of days in the **시뮬레이션 하기** form to see a table of


### PR DESCRIPTION
## Summary
- implement adaptive trading strategy in simulation
- show note when no buy signals occur
- update command line script to use adaptive logic
- document updated simulator

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6841a14dfd10832b8137ba7ff9ea4432