### PR TITLE
Fix no-buy message

### DIFF
--- a/simulation.py
+++ b/simulation.py
@@ -18,6 +18,7 @@ def simulate(ticker, balance=10000, days=5):
     if not predictions:
         print('Unable to generate predictions')
         return
+    no_buy_expected = not any(p > last_close for p in predictions)
 
     current_price = last_close
     cash = balance
@@ -25,7 +26,7 @@ def simulate(ticker, balance=10000, days=5):
     bought = False
     for i, price in enumerate(predictions, start=1):
         action = 'HOLD'
-        if price > current_price and cash >= current_price:
+        if price > current_price and price > last_close and cash >= current_price:
             shares_to_buy = cash / current_price
             cash -= shares_to_buy * current_price
             shares += shares_to_buy
@@ -42,7 +43,7 @@ def simulate(ticker, balance=10000, days=5):
     if shares > 0:
         cash += shares * current_price
         print(f'Final sell {shares:.2f} shares at {current_price:.2f}, total ${cash:.2f}')
-    if not bought:
+    if not bought or no_buy_expected:
         print('지속적인 하락새로 인한 해당기간내에 매수의견이 없습니다.')
 
 

--- a/stocks.py
+++ b/stocks.py
@@ -176,7 +176,9 @@ def run_simulation(data, predictions, balance):
         return [], [], ""
 
     last_date = data.index[-1]
-    current_price = float(data['Close'].iloc[-1])
+    start_price = float(data['Close'].iloc[-1])
+    current_price = start_price
+    no_buy_expected = not any(p > start_price for p in predictions)
     cash = balance
     shares = 0.0
     trades = []
@@ -187,8 +189,8 @@ def run_simulation(data, predictions, balance):
         date = (last_date + pd.Timedelta(days=i)).strftime('%Y-%m-%d')
         action = None
 
-        if price > current_price and cash >= current_price:
-            # Buy as price expected to rise
+        if price > current_price and price > start_price and cash >= current_price:
+            # Buy as price expected to rise beyond the starting price
             shares_to_buy = cash / current_price
             cash -= shares_to_buy * current_price
             shares += shares_to_buy
@@ -224,7 +226,7 @@ def run_simulation(data, predictions, balance):
             'value': cash + shares * current_price,
         })
 
-    note = '' if bought else '지속적인 하락새로 인한 해당기간내에 매수의견이 없습니다.'
+    note = '' if bought and not no_buy_expected else '지속적인 하락새로 인한 해당기간내에 매수의견이 없습니다.'
     return results, trades, note
 
 index_template = """


### PR DESCRIPTION
## Summary
- update simulation to detect downtrends
- show the no-buy notice whenever predictions stay below the last close

## Testing
- `python -m py_compile simulation.py stocks.py`

------
https://chatgpt.com/codex/tasks/task_e_6841a692b004832b819750044b8d7428