### PR TITLE
Fix simulation note visibility and finalize sell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.db
+__pycache__/
+.env
+*.env

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ pip install -r requirements.txt
 
 Set `OPENAI_API_KEY` in your environment to enable GPT-powered sentiment
 analysis and price predictions.
+Set `FLASK_SECRET_KEY` to configure the Flask session secret.
 
 ## Usage
 

--- a/app.py
+++ b/app.py
@@ -1,11 +1,12 @@
 from flask import Flask
+import os
 
 import db
 from auth import bp as auth_bp
 from stocks import bp as stocks_bp
 
 app = Flask(__name__)
-app.secret_key = 'change-me'
+app.secret_key = os.environ.get("FLASK_SECRET_KEY", os.urandom(24))
 
 app.register_blueprint(auth_bp)
 app.register_blueprint(stocks_bp)

--- a/stocks.py
+++ b/stocks.py
@@ -216,15 +216,17 @@ def run_simulation(data, predictions, balance):
 
         current_price = price
 
-    # Final summary if still holding shares
+    # Final sell if still holding shares
     if shares > 0:
+        cash += shares * current_price
         trades.append({
             'date': (last_date + pd.Timedelta(days=len(predictions))).strftime('%Y-%m-%d'),
-            'action': 'HOLDING',
+            'action': 'SELL',
             'shares': shares,
             'price': current_price,
-            'value': cash + shares * current_price,
+            'value': cash,
         })
+        shares = 0
 
     note = '' if bought and not no_buy_expected else '지속적인 하락새로 인한 해당기간내에 매수의견이 없습니다.'
     return results, trades, note
@@ -374,9 +376,9 @@ template = """
     <div class=\"mt-4\">
       {{ profit_graph|safe }}
     </div>
+    {% endif %}
     {% if note %}
     <div class=\"alert alert-info mt-3\">{{ note }}</div>
-    {% endif %}
     {% endif %}
     <h2 class=\"mt-4\">평균 뉴스 감정: {{ sentiment_label }}</h2>
     <h2 class=\"mt-4\">최근 뉴스</h2>


### PR DESCRIPTION
## Summary
- show simulation note even when no trades are present
- close open positions with a final sell
- load Flask secret key from `FLASK_SECRET_KEY`
- document new environment variable and add `.gitignore`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6841ab7fe160832b9d7d0d97a91a827f