### PR TITLE
Improve news API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ pip install -r requirements.txt
 
 Set `OPENAI_API_KEY` in your environment to enable GPT-powered sentiment
 analysis and price predictions.
-Set `ALPHA_VANTAGE_KEY` to fetch stock prices and news from Alpha Vantage.
+Set `ALPHA_VANTAGE_KEY` to fetch stock prices and news from Alpha Vantage. If
+this key is not provided or the Alpha Vantage request fails, the application
+automatically falls back to the free Yahoo Finance RSS feed for headlines.
 Set `FLASK_SECRET_KEY` to configure the Flask session secret.
 To send verification emails during registration you must configure Mailgun by
 setting `MAILGUN_API_KEY` and `MAILGUN_DOMAIN`. Specify `MAILGUN_FROM` if you

--- a/stocks.py
+++ b/stocks.py
@@ -103,7 +103,12 @@ def predict_prices(data, days=5, sentiment=0.0):
 
 
 def fetch_news(ticker):
-    """Return a list of recent news articles for the given ticker."""
+    """Return a list of recent news articles for the given ticker.
+
+    Uses Alpha Vantage's ``NEWS_SENTIMENT`` endpoint when an ``ALPHA_VANTAGE_KEY``
+    is configured. If the key is missing or the request fails, headlines are
+    retrieved from the Yahoo Finance RSS feed instead.
+    """
     news = []
     if ALPHA_VANTAGE_KEY:
         try:


### PR DESCRIPTION
## Summary
- explain that news headlines fall back to Yahoo RSS when Alpha Vantage fails
- clarify fetch_news docstring with fallback description

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6844246bed08832ba8b736be62a71fab