### PR TITLE
Update env requirements and error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ analysis and price predictions.
 Set `FINNHUB_API_KEY` to fetch stock prices and news from Finnhub. If this key
 is not provided or the Finnhub request fails, the application automatically
 falls back to the free Yahoo Finance RSS feed for headlines.
+This variable must be set in your environment (or passed through Docker Compose)
+before starting the application or container.
 Set `FLASK_SECRET_KEY` to configure the Flask session secret.
 To send verification emails during registration you must configure Mailgun by
 setting `MAILGUN_API_KEY` and `MAILGUN_DOMAIN`. Specify `MAILGUN_FROM` if you

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     environment:
       - FLASK_SECRET_KEY=changeme
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - FINNHUB_API_KEY=${FINNHUB_API_KEY}
       - MAILGUN_API_KEY=${MAILGUN_API_KEY}
       - MAILGUN_DOMAIN=${MAILGUN_DOMAIN}
       - MAILGUN_FROM=${MAILGUN_FROM}

--- a/stocks.py
+++ b/stocks.py
@@ -43,7 +43,7 @@ def fetch_stock_history(ticker, period='5d'):
     resp = requests.get("https://finnhub.io/api/v1/stock/candle", params=params, timeout=10)
     data = resp.json()
     if data.get("s") != "ok":
-        raise ValueError("Failed to fetch data from Finnhub")
+        raise ValueError(f"Finnhub error: {data}")
 
     df = pd.DataFrame(
         {


### PR DESCRIPTION
## Summary
- pass FINNHUB_API_KEY through docker compose
- show detailed Finnhub errors when fetching history
- document the need to set FINNHUB_API_KEY before starting

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684431124fec832b95e9c7c22c57ba13