### PR TITLE
Handle Polygon delayed status

### DIFF
--- a/stocks.py
+++ b/stocks.py
@@ -40,7 +40,9 @@ def fetch_stock_history(ticker, period='5d'):
     params = {"adjusted": "true", "sort": "asc", "apiKey": POLYGON_API_KEY}
     resp = requests.get(url, params=params, timeout=10)
     data = resp.json()
-    if data.get("status") != "OK" or not data.get("results"):
+    # Polygon sometimes returns a "DELAYED" status even when data is valid,
+    # so treat it the same as "OK" when results are present.
+    if data.get("status") not in ("OK", "DELAYED") or not data.get("results"):
         raise ValueError(f"Polygon error: {data}")
 
     results = data.get("results", [])


### PR DESCRIPTION
## Summary
- treat "DELAYED" Polygon status like "OK" in `fetch_stock_history`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684441bbe56c832b9d6066d8289a7d1f