### PR TITLE
Show reasoning text without running simulation

### DIFF
--- a/stocks.py
+++ b/stocks.py
@@ -462,14 +462,16 @@ template = """
         </tbody>
       </table>
     </div>
+    {% endif %}
     <div class=\"mt-4\">
+      {% if profit_graph %}
       {{ profit_graph|safe }}
+      {% endif %}
       <p class=\"mt-2 text-muted\">
         예측된 종가: {% for p in predictions %}{{ '{:.2f}'.format(p) }}{% if not loop.last %}, {% endif %}{% endfor %}.<br>
         {{ prediction_reason }}
       </p>
     </div>
-    {% endif %}
     {% if note %}
     <div class=\"alert alert-info mt-3\">{{ note }}</div>
     {% endif %}


### PR DESCRIPTION
## Summary
- render the profit table only when simulation trades exist
- always render prediction reason, wrapped with a profit graph check

## Testing
- `python -m py_compile stocks.py app.py auth.py db.py simulation.py`
- *(failed: `ModuleNotFoundError: No module named 'flask'` when trying to run app)*

------
https://chatgpt.com/codex/tasks/task_e_68445c8301ac832b9719ab960211aa82