### PR TITLE
Fix OpenAI message handling

### DIFF
--- a/stocks.py
+++ b/stocks.py
@@ -80,7 +80,7 @@ def gpt_predict_prices(data, days, sentiment):
             messages=[{"role": "user", "content": prompt}],
             temperature=0,
         )
-        text = resp.choices[0].message["content"]
+        text = resp.choices[0].message.content
         nums = re.findall(r"-?\d+\.\d+|-?\d+", text)
         out = [float(n) for n in nums][:days]
         if len(out) == days:
@@ -194,7 +194,7 @@ def gpt_sentiment(news):
             messages=[{"role": "user", "content": prompt}],
             temperature=0,
         )
-        out = resp.choices[0].message["content"].strip()
+        out = resp.choices[0].message.content.strip()
         match = re.search(r"-?\d+\.\d+|-?\d+", out)
         if match:
             return float(match.group())
@@ -244,7 +244,7 @@ def gpt_explain_predictions(predictions, sentiment, news):
             max_tokens=60,
             temperature=0,
         )
-        return resp.choices[0].message["content"].strip()
+        return resp.choices[0].message.content.strip()
     except Exception:
         return ""
 
@@ -469,7 +469,7 @@ template = """
       {% endif %}
       <p class=\"mt-2 text-muted\">
         예측된 종가: {% for p in predictions %}{{ '{:.2f}'.format(p) }}{% if not loop.last %}, {% endif %}{% endfor %}.<br>
-        {{ prediction_reason }}
+        {% if simulation %}{{ prediction_reason }}{% endif %}
       </p>
     </div>
     {% if note %}


### PR DESCRIPTION
## Summary
- update OpenAI chat response handling to use the new SDK `content` attribute
- show the GPT reasoning only once the simulation has been run

## Testing
- `python -m py_compile app.py auth.py db.py stocks.py simulation.py`


------
https://chatgpt.com/codex/tasks/task_e_68445f77e988832bb2db4eeeaa871f70