### PR TITLE
Replace Plotly charts with canvas

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 Flask
-plotly
 feedparser
 vaderSentiment
 openai>=1.0.0


### PR DESCRIPTION
## Summary
- remove Plotly dependency
- implement custom canvas chart helper
- output chart data arrays and use `<canvas>` instead of Plotly

## Testing
- `python -m py_compile app.py auth.py db.py simulation.py stocks.py`


------
https://chatgpt.com/codex/tasks/task_e_6846fc445924832b86aed933901ab3c2