### PR TITLE
Add trade anomaly detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,15 @@ The web server will be available at `http://localhost:5000/`. The SQLite
 database file is stored on the host in the `data` directory so that your saved
 tickers persist between runs.
 
+## Anomaly Detection
+
+The `anomalies.py` module flags spikes in trade activity using Polygon's
+advanced tick endpoint. Run it from the command line:
+
+```bash
+python anomalies.py AAPL 2023-09-15 2
+```
+
+Or visit `/anomalies/<ticker>?date=YYYY-MM-DD&threshold=2` to see the
+detected periods in the browser.
+

--- a/anomalies.py
+++ b/anomalies.py
@@ -1,0 +1,67 @@
+import os
+import datetime as dt
+import requests
+import pandas as pd
+
+POLYGON_API_KEY = os.getenv("POLYGON_API_KEY")
+
+
+def fetch_ticks(ticker: str, date: str):
+    """Fetch raw tick data for a single trading day using Polygon's v3 endpoint."""
+    if not POLYGON_API_KEY:
+        raise ValueError("POLYGON_API_KEY not set")
+    url = f"https://api.polygon.io/v3/trades/{ticker}"
+    params = {
+        "timestamp.gte": f"{date}T04:00:00Z",
+        "timestamp.lte": f"{date}T20:00:00Z",
+        "limit": 50000,
+        "apiKey": POLYGON_API_KEY,
+    }
+    trades = []
+    while True:
+        resp = requests.get(url, params=params, timeout=10)
+        data = resp.json()
+        trades.extend(data.get("results", []))
+        next_url = data.get("next_url")
+        if not next_url:
+            break
+        url = next_url
+        params = {"apiKey": POLYGON_API_KEY}
+    return trades
+
+
+def detect_anomalies(ticker: str, date: str, threshold: float = 3.0):
+    """Return trade count anomalies for the given ticker and date."""
+    trades = fetch_ticks(ticker, date)
+    if not trades:
+        return pd.Series(dtype=int), 0.0, 0.0
+    df = pd.DataFrame(trades)
+    df["time"] = pd.to_datetime(df["sip_timestamp"], unit="ns")
+    counts = df.resample("1min", on="time").size()
+    mean = counts.mean()
+    std = counts.std()
+    anomalies = counts[counts > mean + threshold * std]
+    return anomalies, mean, std
+
+
+def main():
+    import sys
+
+    if len(sys.argv) < 2:
+        print("Usage: python anomalies.py TICKER [YYYY-MM-DD] [threshold]")
+        return
+    ticker = sys.argv[1].upper()
+    date = sys.argv[2] if len(sys.argv) > 2 else dt.date.today().strftime("%Y-%m-%d")
+    threshold = float(sys.argv[3]) if len(sys.argv) > 3 else 3.0
+
+    anomalies, mean, std = detect_anomalies(ticker, date, threshold)
+    if anomalies.empty:
+        print("No anomalies detected")
+    else:
+        print(f"Anomalies for {ticker} on {date} (mean {mean:.2f}, std {std:.2f})")
+        for ts, count in anomalies.items():
+            print(ts.strftime("%H:%M"), int(count))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement `anomalies.py` for detecting abnormal trade volumes using Polygon v3 trades
- expose `/anomalies/<ticker>` route to view anomalies in the browser
- document how to use the new module and route

## Testing
- `pip install -q -r requirements.txt`
- `python -m py_compile anomalies.py stocks.py app.py auth.py db.py simulation.py`
- `POLYGON_API_KEY=invalid python anomalies.py AAPL 2023-01-03 2 | head -n 10`

------
https://chatgpt.com/codex/tasks/task_e_6847e02c594c832bb50a4d926ec8458f